### PR TITLE
axis change of make_leave_one_out

### DIFF
--- a/src/data_utils.py
+++ b/src/data_utils.py
@@ -172,10 +172,11 @@ def make_leave_one_out(array: chex.Array, axis: int) -> chex.Array:
     Returns:
         Array of shape (*B, N, N-1, *H).
     """
+    axis = axis % array.ndim
     output = []
     for i in range(array.shape[axis]):
         array_before = jax.lax.slice_in_dim(array, 0, i, axis=axis)
         array_after = jax.lax.slice_in_dim(array, i + 1, array.shape[axis], axis=axis)
         output.append(jnp.concatenate([array_before, array_after], axis=axis))
-    output = jnp.stack(output, axis=axis - 1)
+    output = jnp.stack(output, axis=axis)
     return output


### PR DESCRIPTION
current implementation asumes the axis is going to be expressed as a negative number, and has different behaviour if its expressed as a positive number.

for example, if the input tensor shape is (5,4,6), the output with axis =1 and axis=-2 should have shape (5,4,3,6)